### PR TITLE
typo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,7 @@ Some features above are not implemented in 'ICU' (i.e., the stringi package), an
 ## Installation
 
 ```r
-remotes::install_github("paithio909/audubon")
+remotes::install_github("paithiov909/audubon")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ additional features.
 ## Installation
 
 ``` r
-remotes::install_github("paithio909/audubon")
+remotes::install_github("paithiov909/audubon")
 ```
 
 ## Usage


### PR DESCRIPTION
README中のパッケージインストールのためのコマンドに脱字がありましたので修正しました。
（パッケージをインストールしようとして気がつきました）